### PR TITLE
Sparkpost tracking config option

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -7,4 +7,7 @@ return [
     'description' => 'Sparkpost Mailer Plugin for Mautic',
     'version'     => '1.0.0',
     'author'      => 'Acquia',
+    'parameters'  => [
+        'sparkpost_tracking_enabled' => false,
+    ],
 ];

--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -18,7 +18,7 @@ class CallbackSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private TransportCallback $transportCallback,
-        private CoreParametersHelper $coreParametersHelper
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/Mailer/Factory/SparkpostTransportFactory.php
+++ b/Mailer/Factory/SparkpostTransportFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\SparkpostBundle\Mailer\Factory;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Model\TransportCallback;
 use MauticPlugin\SparkpostBundle\Mailer\Transport\SparkpostTransport;
 use Psr\Log\LoggerInterface;
@@ -21,9 +22,10 @@ class SparkpostTransportFactory extends AbstractTransportFactory
     public function __construct(
         private TransportCallback $transportCallback,
         private TranslatorInterface $translator,
+        private CoreParametersHelper $coreParametersHelper,
         EventDispatcherInterface $eventDispatcher,
         HttpClientInterface $client = null,
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
     ) {
         parent::__construct($eventDispatcher, $client, $logger);
     }
@@ -51,9 +53,10 @@ class SparkpostTransportFactory extends AbstractTransportFactory
                 $this->getPassword($dsn),
                 $region,
                 $this->transportCallback,
+                $this->coreParametersHelper,
                 $this->client,
                 $this->dispatcher,
-                $this->logger
+                $this->logger,
             );
         }
 

--- a/Mailer/Transport/SparkpostTransport.php
+++ b/Mailer/Transport/SparkpostTransport.php
@@ -24,7 +24,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\ParameterizedHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -72,10 +72,6 @@ class SparkpostTransport extends AbstractApiTransport implements TokenTransportI
     }
 
     /**
-     * @throws ClientExceptionInterface
-     * @throws DecodingExceptionInterface
-     * @throws RedirectionExceptionInterface
-     * @throws ServerExceptionInterface
      * @throws TransportExceptionInterface
      */
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
@@ -94,8 +90,8 @@ class SparkpostTransport extends AbstractApiTransport implements TokenTransportI
             }
 
             return $response;
-        } catch (\Exception $e) {
-            throw new TransportException($e->getMessage());
+        } catch (ExceptionInterface $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,46 @@
-### Mautic Sparkpost Plugin
+# Mautic Sparkpost Plugin
 
 This plugin enable Mautic 5 to run Sparkpost as an email transport. Features:
 - API transport. This transport can send up to 2000 emails per API request which makes it very fast compared to SMTP.
 - Bounce webhook handling. This plugin will unsubscribe contacts in Mautic based on the hard bounces while Sparkpost will take care of the soft bounce retrieals.
 
+## Installation
 
-#### Mautic Mailer DSN Scheme
+There are several ways how to install this plugin. Here are the options from best to worst.
+
+### Via Composer
+
+This is the best option for Mautic instances that were installed via Composer (recommended way to install Mautic)
+
+Steps:
+1. `composer install acquia/mc-cs-plugin-sparkpost`
+2. `bin/console mautic:plugins:install`
+
+### Via Git
+
+This option is useful for development or testing of this plugin as you'll be able to checkout different branches of this repository.
+
+Steps:
+1. `cd plugins`
+2. `git clone git@github.com:acquia/mc-cs-plugin-sparkpost.git SparkpostBundle`
+3. `cd ..`
+4. `bin/console mautic:plugins:install`
+
+### Via SFTP
+
+You should reconsider using this method as the other two above are way better, but this is also possible.
+
+Steps:
+1. [Download this plugin](https://github.com/acquia/mc-cs-plugin-sparkpost/archive/refs/heads/main.zip)
+2. Rename the folder `mc-cs-plugin-sparkpost-main` to `SparkpostBundle`
+3. Upload this folder to the `plugins` directory of your Mautic files.
+4. `bin/console mautic:plugins:install`
+
+## Configuration
+
+After the plugin is installed go to the Mautic's global configuration, the Email settings and configure the DSN.
+
+### Mautic Mailer DSN Scheme
 `mautic+sparkpost+api`
 
 #### Mautic Mailer DSN Example
@@ -16,7 +51,15 @@ This plugin enable Mautic 5 to run Sparkpost as an email transport. Features:
 
 <img width="1105" alt="sparkpost-email-dsn-example" src="Assets/img/sparkpost-email-dsn-example.png">
 
-### Testing
+### Sparkpost tracking
+
+The Sparkpost tracking is disabled by default as then the email open and clicks would be tracked twice. Once by Sparkpost, second time by Mautic. This can create some unexpected behavior. The Sparkpost tracking is disabled by default, but you can enable it by adding this row to the Mautic configuration file located at `config/local.php`:
+
+```php
+'sparkpost_tracking_enabled' => true,
+```
+
+## Testing
 
 To run all tests `composer phpunit`
 

--- a/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
@@ -36,7 +36,6 @@ class SparkpostTransportTest extends MauticMysqlTestCase
      */
     public function testEmailSendToContactSync(bool $expectedTrackingConfig): void
     {
-        $this->client->catchExceptions(false);
         $expectedResponses = [
             function ($method, $url, $options) use ($expectedTrackingConfig): MockResponse {
                 Assert::assertSame(Request::METHOD_POST, $method);

--- a/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
@@ -26,7 +26,7 @@ class SparkpostTransportTest extends MauticMysqlTestCase
         $this->configParams['mailer_custom_headers']      = ['x-global-custom-header' => 'value123'];
         $this->configParams['mailer_from_email']          = 'admin@mautic.test';
         $this->configParams['mailer_from_name']           = 'Admin';
-        $this->configParams['sparkpost_tracking_enabled'] = $this->getName() === 'testEmailSendToContactSync' ? $this->getProvidedData()[0] : false;
+        $this->configParams['sparkpost_tracking_enabled'] = 'testEmailSendToContactSync' === $this->getName() ? $this->getProvidedData()[0] : false;
         parent::setUp();
         $this->translator = self::getContainer()->get('translator');
     }

--- a/Tests/Unit/Mailer/Factory/SparkpostTransportFactoryTest.php
+++ b/Tests/Unit/Mailer/Factory/SparkpostTransportFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\SparkpostBundle\Tests\Unit\Mailer\Factory;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Model\TransportCallback;
 use MauticPlugin\SparkpostBundle\Mailer\Factory\SparkpostTransportFactory;
 use MauticPlugin\SparkpostBundle\Mailer\Transport\SparkpostTransport;
@@ -22,19 +23,22 @@ class SparkpostTransportFactoryTest extends TestCase
 {
     private SparkpostTransportFactory $sparkpostTransportFactory;
 
-    private TranslatorInterface|MockObject $translatorMock;
+    private TranslatorInterface&MockObject $translatorMock;
+    private CoreParametersHelper&MockObject $coreParametersHelper;
 
     protected function setUp(): void
     {
-        $eventDispatcherMock   = $this->createMock(EventDispatcherInterface::class);
-        $this->translatorMock  = $this->createMock(TranslatorInterface::class);
-        $transportCallbackMock = $this->createMock(TransportCallback::class);
-        $httpClientMock        = $this->createMock(HttpClientInterface::class);
-        $loggerMock            = $this->createMock(LoggerInterface::class);
+        $eventDispatcherMock        = $this->createMock(EventDispatcherInterface::class);
+        $this->translatorMock       = $this->createMock(TranslatorInterface::class);
+        $transportCallbackMock      = $this->createMock(TransportCallback::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $httpClientMock             = $this->createMock(HttpClientInterface::class);
+        $loggerMock                 = $this->createMock(LoggerInterface::class);
 
         $this->sparkpostTransportFactory = new SparkpostTransportFactory(
             $transportCallbackMock,
             $this->translatorMock,
+            $this->coreParametersHelper,
             $eventDispatcherMock,
             $httpClientMock,
             $loggerMock

--- a/Tests/Unit/Mailer/Factory/SparkpostTransportFactoryTest.php
+++ b/Tests/Unit/Mailer/Factory/SparkpostTransportFactoryTest.php
@@ -23,8 +23,15 @@ class SparkpostTransportFactoryTest extends TestCase
 {
     private SparkpostTransportFactory $sparkpostTransportFactory;
 
-    private TranslatorInterface&MockObject $translatorMock;
-    private CoreParametersHelper&MockObject $coreParametersHelper;
+    /**
+     * @var TranslatorInterface&MockObject
+     */
+    private MockObject $translatorMock;
+
+    /**
+     * @var CoreParametersHelper&MockObject
+     */
+    private MockObject $coreParametersHelper;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Mailer/Transport/SparkpostTransportMessageTest.php
+++ b/Tests/Unit/Mailer/Transport/SparkpostTransportMessageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\SparkpostBundle\Tests\Unit\Mailer\Transport;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\EmailBundle\Model\TransportCallback;
 use MauticPlugin\SparkpostBundle\Mailer\Transport\SparkpostTransport;
@@ -27,6 +28,7 @@ class SparkpostTransportMessageTest extends TestCase
 
         $transportCallbackMock = $this->createMock(TransportCallback::class);
         $httpClientMock        = $this->createMock(HttpClientInterface::class);
+        $coreParametersHelper  = $this->createMock(CoreParametersHelper::class);
         $eventDispatcherMock   = $this->createMock(EventDispatcherInterface::class);
         $loggerMock            = $this->createMock(LoggerInterface::class);
 
@@ -34,6 +36,7 @@ class SparkpostTransportMessageTest extends TestCase
             '1234',
             'us',
             $transportCallbackMock,
+            $coreParametersHelper,
             $httpClientMock,
             $eventDispatcherMock,
             $loggerMock

--- a/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
@@ -22,15 +22,30 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SparkpostTransportTest extends TestCase
 {
-    private TransportCallback|MockObject $transportCallbackMock;
+    /**
+     * @var TransportCallback&MockObject
+     */
+    private MockObject $transportCallbackMock;
 
-    private CoreParametersHelper&MockObject $coreParametersHelper;
+    /**
+     * @var CoreParametersHelper&MockObject
+     */
+    private MockObject $coreParametersHelper;
 
-    private HttpClientInterface|MockObject $httpClientMock;
+    /**
+     * @var HttpClientInterface&MockObject
+     */
+    private MockObject $httpClientMock;
 
-    private EventDispatcherInterface|MockObject $eventDispatcherMock;
+    /**
+     * @var EventDispatcherInterface&MockObject
+     */
+    private MockObject $eventDispatcherMock;
 
-    private LoggerInterface|MockObject $loggerMock;
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private MockObject $loggerMock;
 
     private SparkpostTransport $transport;
 

--- a/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\SparkpostBundle\Tests\Unit\Mailer\Transport;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\EmailBundle\Model\TransportCallback;
 use MauticPlugin\SparkpostBundle\Mailer\Transport\SparkpostTransport;
@@ -23,6 +24,8 @@ class SparkpostTransportTest extends TestCase
 {
     private TransportCallback|MockObject $transportCallbackMock;
 
+    private CoreParametersHelper&MockObject $coreParametersHelper;
+
     private HttpClientInterface|MockObject $httpClientMock;
 
     private EventDispatcherInterface|MockObject $eventDispatcherMock;
@@ -34,6 +37,7 @@ class SparkpostTransportTest extends TestCase
     protected function setUp(): void
     {
         $this->transportCallbackMock = $this->createMock(TransportCallback::class);
+        $this->coreParametersHelper  = $this->createMock(CoreParametersHelper::class);
         $this->httpClientMock        = $this->createMock(HttpClientInterface::class);
         $this->eventDispatcherMock   = $this->createMock(EventDispatcherInterface::class);
         $this->loggerMock            = $this->createMock(LoggerInterface::class);
@@ -41,6 +45,7 @@ class SparkpostTransportTest extends TestCase
             'api-key',
             'some-region',
             $this->transportCallbackMock,
+            $this->coreParametersHelper,
             $this->httpClientMock,
             $this->eventDispatcherMock,
             $this->loggerMock


### PR DESCRIPTION
**Motivation**
The Sparkpost email open and click tracking was always disabled. This PR keeps it disabled but allows users to enable it via a configuration option `sparkpost_tracking_enabled`

**Testing steps**
1. Send an email with some link via Sparkpost without any change in configuraiton. You should see by hovering over the link in the email that the URL goes to Mautic first. If you click the link Mautic redirects you to the original location. You should see the click event in Mautic but not in Sparkpost.
2. Enable the Sparkpost tracking (See the changes in the readme)
3. Send an email with some link via Sparkpost. You should see by hovering over the link in the email that the URL goes to Sparkpost first. If you click the link then Sparkpost redirects you to Mautic and Mautic redirects you to the original location. You should see the click event in Mautic as well as in Sparkpost.
