### PR TITLE
M7 support + Sparkpost response validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.4'] # The supported PHP versions
+        php-versions: ['8.2', '8.4'] # The supported PHP versions
         db-types: ['mysql'] # can be: ['mysql', 'mariadb'] but not necessary for this plugin that does not add any DB schema
-        mautic-versions: [6.x, 7.x] # The supported Mautic versions
+        mautic-versions: [7.x] # The supported Mautic versions
 
     name: Tests on PHP ${{ matrix.php-versions }}, ${{ matrix.db-types }}, Mautic ${{ matrix.mautic-versions }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,15 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1'] # The supported PHP versions
+        php-versions: ['8.1', '8.4'] # The supported PHP versions
         db-types: ['mysql'] # can be: ['mysql', 'mariadb'] but not necessary for this plugin that does not add any DB schema
-        mautic-versions: [6.x] # The supported Mautic versions
+        mautic-versions: [6.x, 7.x] # The supported Mautic versions
 
     name: Tests on PHP ${{ matrix.php-versions }}, ${{ matrix.db-types }}, Mautic ${{ matrix.mautic-versions }}
 
     services:
       database:
-        image: ${{ matrix.db-types == 'mysql' && 'mysql:8.0' || 'mariadb:10.3' }}
+        image: ${{ matrix.db-types == 'mysql' && 'mysql:8.4' || 'mariadb:10.3' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: mautictest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,5 +129,5 @@ jobs:
       - name: Upload logs as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: mautic-logs
+          name: mautic-logs-php-${{ matrix.php-versions }}-${{ matrix.db-types }}-mautic-${{ matrix.mautic-versions }}
           path: var/logs/

--- a/Mailer/Factory/SparkpostTransportFactory.php
+++ b/Mailer/Factory/SparkpostTransportFactory.php
@@ -24,8 +24,8 @@ class SparkpostTransportFactory extends AbstractTransportFactory
         private TranslatorInterface $translator,
         private CoreParametersHelper $coreParametersHelper,
         EventDispatcherInterface $eventDispatcher,
-        HttpClientInterface $client = null,
-        LoggerInterface $logger = null,
+        ?HttpClientInterface $client = null,
+        ?LoggerInterface $logger = null,
     ) {
         parent::__construct($eventDispatcher, $client, $logger);
     }

--- a/Mailer/Transport/SparkpostTransport.php
+++ b/Mailer/Transport/SparkpostTransport.php
@@ -390,11 +390,16 @@ class SparkpostTransport extends AbstractApiTransport implements TokenTransportI
      */
     private function handleError(ResponseInterface $response): void
     {
+        $data = json_decode($response->getContent(false), true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new HttpTransportException(sprintf('Invalid Sparkpost JSON response. JSON error: "%s", HTTP status code: %d, HTTP response string: "%s"', json_last_error_msg(), $response->getStatusCode(), $response->getContent(false)), $response, $response->getStatusCode());
+        }
+
         if (200 === $response->getStatusCode()) {
             return;
         }
 
-        $data = json_decode($response->getContent(false), true);
         $this->getLogger()->error('SparkpostApiTransport error response', $data);
 
         throw new HttpTransportException(json_encode($data['errors']), $response, $response->getStatusCode());

--- a/Mailer/Transport/SparkpostTransport.php
+++ b/Mailer/Transport/SparkpostTransport.php
@@ -58,9 +58,9 @@ class SparkpostTransport extends AbstractApiTransport implements TokenTransportI
         string $region,
         private TransportCallback $callback,
         private CoreParametersHelper $coreParametersHelper,
-        HttpClientInterface $client = null,
-        EventDispatcherInterface $dispatcher = null,
-        LoggerInterface $logger = null,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
     ) {
         parent::__construct($client, $dispatcher, $logger);
         $this->host = self::SPARK_POST_HOSTS[$region] ?? self::SPARK_POST_HOSTS['us'];

--- a/Tests/Functional/Mailer/Transport/SparkpostTransportFunctionalTest.php
+++ b/Tests/Functional/Mailer/Transport/SparkpostTransportFunctionalTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\SparkpostBundle\Tests\Functional\Mailer\Transport;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Mailer\Message\MauticMessage;
+use MauticPlugin\SparkpostBundle\Mailer\Transport\SparkpostTransport;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mime\Address;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class SparkpostTransportFunctionalTest extends MauticMysqlTestCase
+{
+    private SparkpostTransport $sparkpostTranport;
+    private HttpClientInterface $mockHttpClient;
+
+    protected function setUp(): void
+    {
+        $this->configParams['mailer_dsn']          = 'mautic+sparkpost+api://:test_api_key@default?region=us';
+        $this->configParams['messenger_dsn_email'] = 'sync://';
+
+        parent::setUp();
+
+        $this->mockHttpClient = self::getContainer()->get(HttpClientInterface::class);
+
+        // Create the transport directly since it's not registered as a service
+        $callback             = self::getContainer()->get('mautic.email.model.transport_callback');
+        $coreParametersHelper = self::getContainer()->get('mautic.helper.core_parameters');
+
+        $this->sparkpostTranport = new SparkpostTransport(
+            'test_api_key',
+            'us',
+            $callback,
+            $coreParametersHelper,
+            $this->mockHttpClient
+        );
+    }
+
+    public function testTemplateValidationRequestFailsDuringSendWithNull(): void
+    {
+        /** @var MockHttpClient $mockHttpClient */
+        $mockHttpClient = $this->mockHttpClient;
+        $mockHttpClient->setResponseFactory([
+            function (string $method, string $url, array $options): MockResponse {
+                Assert::assertSame(Request::METHOD_POST, $method);
+                Assert::assertSame('https://api.sparkpost.com/api/v1/utils/content-previewer/', $url);
+                Assert::assertSame('{"content":{"from":"John Doe \u003Cjohn@doe.email\u003E","subject":"Subject line","headers":{},"html":"Hello, John","text":"Hello, John","reply_to":"john@doe.email","attachments":[]},"inline_css":null,"tags":[],"campaign_id":"","options":{"open_tracking":false,"click_tracking":false},"substitution_data":{}}', $options['body']);
+
+                return new MockResponse('invalid json');
+            },
+        ]);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Invalid Sparkpost JSON response. JSON error: "Syntax error", HTTP status code: 200, HTTP response string: "invalid json"');
+
+        $this->sparkpostTranport->send($this->createTestEmail());
+    }
+
+    /**
+     * Creates a test email using Mautic's MauticMessage.
+     */
+    private function createTestEmail(): MauticMessage
+    {
+        $email = new MauticMessage();
+        $email->from(new Address('john@doe.email', 'John Doe'))
+            ->to(new Address('recipient@example.com'))
+            ->subject('Subject line')
+            ->html('Hello, John')
+            ->text('Hello, John');
+
+        return $email;
+    }
+}

--- a/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
@@ -196,31 +196,31 @@ class SparkpostTransportTest extends MauticMysqlTestCase
         // Inject the dynamic DSN option inputs that would normally be added via JavaScript
         // This simulates the user clicking the button to add DSN options
         $html = $this->client->getResponse()->getContent();
-        
+
         // Inject both the label and value inputs for the DSN option
         // The label should be set to "region" and the value to the test value
         $injectedInputs = '
             <input type="text" id="config_emailconfig_mailer_dsn_options_list_0_label" name="config[emailconfig][mailer_dsn][options][list][0][label]" class="form-control sortable-label" placeholder="Label" autocomplete="false" value="">
             <input type="text" id="config_emailconfig_mailer_dsn_options_list_0_value" name="config[emailconfig][mailer_dsn][options][list][0][value]" class="form-control sortable-value" placeholder="Value" autocomplete="false" value="">
         ';
-        
+
         // Inject the inputs before the closing form tag
-        $html = str_replace('</form>', $injectedInputs . '</form>', $html);
-        
+        $html = str_replace('</form>', $injectedInputs.'</form>', $html);
+
         // Create a new crawler with the modified HTML
         $crawler = new Crawler($html, $this->client->getInternalRequest()->getUri());
 
         // Set form data - we need to set the DSN scheme to sparkpost for validation to trigger
         $form = $crawler->selectButton('config[buttons][save]')->form();
         $form->setValues([
-            'config[emailconfig][mailer_dsn][scheme]' => 'mautic+sparkpost+api',
-            'config[emailconfig][mailer_dsn][host]' => 'default',
-            'config[emailconfig][mailer_dsn][user]' => '',
-            'config[emailconfig][mailer_dsn][password]' => 'test_api_key',
-            'config[emailconfig][mailer_dsn][port]' => '',
+            'config[emailconfig][mailer_dsn][scheme]'                  => 'mautic+sparkpost+api',
+            'config[emailconfig][mailer_dsn][host]'                    => 'default',
+            'config[emailconfig][mailer_dsn][user]'                    => '',
+            'config[emailconfig][mailer_dsn][password]'                => 'test_api_key',
+            'config[emailconfig][mailer_dsn][port]'                    => '',
             'config[emailconfig][mailer_dsn][options][list][0][label]' => 'region',
             'config[emailconfig][mailer_dsn][options][list][0][value]' => $regionValue,
-            'config[leadconfig][contact_columns]' => ['name', 'email', 'id'],
+            'config[leadconfig][contact_columns]'                      => ['name', 'email', 'id'],
         ]);
 
         // Submit and check for validation error

--- a/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Functional/Mailer/Transport/SparkpostTransportTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -31,7 +32,7 @@ class SparkpostTransportTest extends MauticMysqlTestCase
         $this->translator = self::getContainer()->get('translator');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideTrackingConfig')]
+    #[DataProvider('provideTrackingConfig')]
     public function testEmailSendToContactSync(bool $expectedTrackingConfig): void
     {
         $expectedResponses = [
@@ -186,7 +187,7 @@ class SparkpostTransportTest extends MauticMysqlTestCase
         return $lead;
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataInvalidDsn')]
+    #[DataProvider('dataInvalidDsn')]
     public function testInvalidDsn(string $regionValue, string $expectedMessage): void
     {
         // Request config edit page

--- a/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
+++ b/Tests/Unit/Mailer/Transport/SparkpostTransportTest.php
@@ -81,6 +81,7 @@ class SparkpostTransportTest extends TestCase
 
         $sentMessageMock->method('getOriginalMessage')->willReturn($mauticMessage);
         $responseMock->method('getStatusCode')->willReturn(200);
+        $responseMock->method('getContent')->willReturn('{}');
 
         /** @phpstan-ignore-next-line */
         $this->httpClientMock->method('request')

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.0.0",
-        "mautic/core-lib": "^5.0"
+        "php": ">=8.1.0",
+        "mautic/core-lib": "^7.0"
     },
     "scripts": {
         "test": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=8.1.0",
+        "php": "~8.2",
         "mautic/core-lib": "^7.0"
     },
     "scripts": {


### PR DESCRIPTION
**Motivation**
1. Updating this plugin to work with Mautic 7-beta.
2. Sparkpost response validation

This PR validates that the response from the Sparkpost API is an array before attempting to use it as one. It addresses an issue found while investigating MAUT-11019, where an error can occur when the response body is null.

**Testing steps**
We should test that emails sent via Sparkpost are working as before, tokens are replacing. Test with at least 300 emails. We are using prod Sparkpost account for testing. Please use the [Sink technique](https://support.sparkpost.com/docs/faq/using-sink-server) to send emails that we don't want anyone to receive and it won't affect our health socore.

Follow [Readme](https://github.com/acquia/mc-cs-plugin-sparkpost?tab=readme-ov-file#mautic-sparkpost-plugin) on how to install and configure the plugin.

Be aware that Mautic 7 can send only 1 email per API request. The fix for it is in https://github.com/mautic/mautic/pull/14019 but blocked by other PR.
